### PR TITLE
Added more port numbers to ipscan_portlist.h

### DIFF
--- a/ipscan_portlist.h
+++ b/ipscan_portlist.h
@@ -43,9 +43,10 @@
 // 0.19 - add TCP/20005 (for KCodes NetUSB - see CVE-2021-45608)
 // 0.20 - update copyright year
 // 0.21 - const portlist structs
+// 0.22 - added many more UDP/TCP ports
 
 //
-#define IPSCAN_PORTLIST_VER "0.21"
+#define IPSCAN_PORTLIST_VER "0.22"
 //
 
 #include "ipscan.h"
@@ -60,43 +61,58 @@
 const struct portlist_struc defportlist[] =
 {
 		{    7, 0, "Echo"},\
+		{   20, 0, "FTP data" },\
 		{   21, 0, "FTP" },\
 		{   22, 0, "SSH" },\
 		{   23, 0, "Telnet" },\
+		{   24, 0, "Private mail system" },\
 		{   25, 0, "SMTP" },\
 		{   37, 0, "Time" },\
 		{   43, 0, "WHOIS" },\
 		{   53, 0, "DNS" },\
 		{   79, 0, "Finger" },\
 		{   80, 0, "HTTP" },\
+		{   81, 0, "HTTP alternate" },\
 		{  110, 0, "POP3" },\
 		{  111, 0, "SUN-RPC" },\
 		{  113, 0, "Ident, Auth" },\
 		{  119, 0, "NNTP" },\
 		{  135, 0, "Microsoft-EPMAP" },\
+		{  137, 0, "NetBIOS" },\
+		{  138, 0, "NetBIOS Datagram" },\
 		{  139, 0, "NetBIOS Session" },\
-		{  143, 0, "IMAP" },\
+		{  143, 0, "IMAP4" },\
+		{  161, 0, "SNMP" },\
 		{  179, 0, "BGP" },\
+		{  194, 0, "IRC" },\
 		{  311, 0, "Apple-WebAdmin" },\
 		{  389, 0, "LDAP" },\
 		{  427, 0, "SLP" },\
 		{  443, 0, "HTTPS" },\
+		{  444, 0, "HTTPS alternate" },\
 		{  445, 0, "Microsoft-DS" },\
+		{  465, 0, "SMTPS" },\
 		{  515, 0, "LPD" },\
 		{  543, 0, "Kerberos Login" },\
 		{  544, 0, "Kerberos RSH" },\
 		{  548, 0, "Apple-File" },\
+		{  563, 0, "NNTPS" },\
 		{  587, 0, "ESMTP" },\
 		{  631, 0, "IPP" },\
 		{  749, 0, "Kerberos Admin" },\
+		{  853, 0, "DNS over TLS" },\
 		{  873, 0, "Rsync" },\
-		{  993, 0, "IMAPS" },\
+		{  989, 0, "FTPS data" },\
+		{  990, 0, "FTPS" },\
+		{  993, 0, "IMAP4S" },\
 		{  995, 0, "POP3S" },\
 		{ 1025, 0, "Blackjack, NFS, IIS or RFS" },\
 		{ 1026, 0, "CAP, Microsoft DCOM" },\
 		{ 1029, 0, "Microsoft DCOM" },\
 		{ 1030, 0, "BBN IAD" },\
 		{ 1080, 0, "Socks" },\
+		{ 1433, 0, "Microsoft SQL" },\
+		{ 1521, 0, "Oracle SQL" },\
 		{ 1720, 0, "H323, Microsoft Netmeeting" },\
 		{ 1723, 0, "PPTP" },\
 		{ 1801, 0, "MSMQ" },\
@@ -105,15 +121,27 @@ const struct portlist_struc defportlist[] =
 		{ 2107, 0, "MSMQ-Mgmt" },\
 		{ 2869, 0, "SSDP Event Notification" },\
 		{ 3128, 0, "Active API, or Squid Proxy" },\
-		{ 3306, 0, "MySQL" },\
+		{ 3306, 0, "MySQL server" },\
 		{ 3389, 0, "Microsoft RDP" },\
 		{ 3689, 0, "DAAP, iTunes" },\
 		{ 5000, 0, "UPNP" },\
+		{ 5000, 1, "Sybase/DB2 SQL" },\
 		{ 5060, 0, "SIP" },\
 		{ 5100, 0, "Service Mux, Yahoo Messenger" },\
 		{ 5357, 0, "WSDAPI HTTP" },\
+		{ 5432, 0, "PostgreSQL" },\
+		{ 5800, 0, "VNC over HTTP" },\
+		{ 5801, 0, "VNC over HTTP alternate" },\
 		{ 5900, 0, "VNC" },\
+		{ 5901, 0, "VNC alternate" },\
+		{ 6379, 0, "Redis cache" },\
+		{ 6380, 0, "Redis cache alternate" },\
+		{ 6667, 0, "IRC encrypted" },\
 		{ 8080, 0, "HTTP alternate" },\
+		{ 8333, 0, "Bitcoin cryptocurrency" },\
+		{ 8545, 0, "Ethereum cryptocurrency JSON-RPC"},\
+		{ 5985, 0, "Microsoft WinRM/WMI/PowerShell HTTP" },\
+		{ 5986, 0, "Microsoft WinRM/WMI/PowerShell HTTPS" },\
 		{ 9090, 0, "WebSM" },\
 		{10243, 0, "Microsoft WMP HTTP"},\
 		{11211, 0, "memcache" },\
@@ -122,7 +150,15 @@ const struct portlist_struc defportlist[] =
 		{16994, 0, "Intel AMT Redir/TCP"},\
 		{16995, 0, "Intel AMT Redir/TLS"},\
 		{20005, 0, "Router KCodes NetUSB port, see CVE-2021-45608"},\
+		{22555, 0, "Dogecoin cryptocurrency JSON-RPC"},\
+		{22556, 0, "Dogecoin cryptocurrency"},\
+		{27017, 0, "MongoDB server"},\
+		{27018, 0, "MongoDB sharding"},\
+		{27019, 0, "MongoDB config"},\
+		{27018, 0, "MongoDB crypto"},\
 		{32764, 0, "Router Backdoor"}\
+		{30301, 0, "Ethereum cryptocurrency discovery"},\
+		{30303, 0, "Ethereum cryptocurrency"},\
 };
 
 
@@ -133,15 +169,21 @@ const struct portlist_struc udpportlist[] =
 {
 		{   53, 0, "DNS" },\
 		{   69, 0, "TFTP" },\
+		{   80, 0, "HTTP/3" },\
+		{   81, 0, "HTTP/3 alternate" },\
 		{  123, 0, "NTP" },\
 		{  123, 1, "NTP MONLIST" },\
 		{  161, 0, "SNMPv1" },\
 		{  161, 1, "SNMPv2c" },\
 		{  161, 2, "SNMPv3" },\
+		{  443, 0, "HTTPS/3" },\
+		{  444, 0, "HTTPS/3 alternate" },\
 		{  500, 0, "IKEv2 SA_INIT" },\
 		{  521, 0, "RIPng" },\
 		{  547, 0, "DHCPv6" },\
+		{  853, 0, "DNS over TLS" },\
 		{ 1900, 0, "UPnP SSDP" },\
+		{ 3389, 0, "Microsoft RDP" },\
 		{ 3503, 0, "MPLS LSP Ping" },\
 		{ 4500, 0, "IKEv2 NAT-T SA_INIT" },\
 		{11211, 0, "memcache ASCII" },\


### PR DESCRIPTION
I added many new TCP and UDP port numbers based on what I've encountered in active use in the field (part of my work involves configuring-and-maintaining Linux firewalls and various aspects of network security).